### PR TITLE
Updated REAME.md with corrected info

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This guide assumes:
     to
     ```
     PLUGINS_CONFIG = {
-        "netbox_bind_provisioner": {
+        "netbox_plugin_bind_provisioner": {
             "catalog_serial_file": "/opt/netbox/catalog-serial.txt",
             "tsig_keys": {
                 "public": {


### PR DESCRIPTION
The PLUGINS_CONFIG example references the incorrect name in the example "netbox_bind_provisioner" should be "netbox_plugin_bind_provisioner"