### PR TITLE
Replace explicit checks for STATUS_ACTIVE with the annotated "active" value

### DIFF
--- a/netbox_dns_bridge/catalog_zone_manager.py
+++ b/netbox_dns_bridge/catalog_zone_manager.py
@@ -12,7 +12,6 @@ import dns.renderer
 import logging
 from .logger import get_logger
 from netbox_dns.models import Zone
-from netbox_dns.choices import ZoneStatusChoices
 from netbox_dns_bridge.models import IntegerKeyValueSetting, CatalogZoneMemberIdentifier
 from uuid import uuid4
 from base64 import b32encode
@@ -101,7 +100,7 @@ def create_zone(name, view_name) -> dns.zone.Zone:
     # Synchronize following across threads as TCP and UDP listener both use it.
     with _LOCK:
         latest_zone = (
-            Zone.objects.filter(status=ZoneStatusChoices.STATUS_ACTIVE)
+            Zone.objects.filter(active=True)
             .order_by("-last_updated")
             .first()
         )
@@ -128,7 +127,7 @@ def create_zone(name, view_name) -> dns.zone.Zone:
 
     # get zones from netbox
     nb_zones = Zone.objects.filter(
-        view__name=view_name, status=ZoneStatusChoices.STATUS_ACTIVE
+        view__name=view_name, active=True
     ).select_related("catz_identifier")
 
     ptr_base = dns.name.from_text("zones", origin)

--- a/netbox_dns_bridge/request_handler.py
+++ b/netbox_dns_bridge/request_handler.py
@@ -13,7 +13,6 @@ import dns.renderer
 import logging
 from .logger import get_logger
 from netbox_dns.models import Zone, Record
-from netbox_dns.choices import ZoneStatusChoices, RecordStatusChoices
 from netbox_dns_bridge import catalog_zone_manager as catzm
 
 logger = get_logger(__name__)
@@ -32,7 +31,7 @@ class DNSBaseRequestHandler(socketserver.BaseRequestHandler):
             nb_zone = Zone.objects.get(
                 name=zone_name,
                 view__name=view_name,
-                status=ZoneStatusChoices.STATUS_ACTIVE,
+                active=True,
             )
         except Zone.DoesNotExist:
             return None
@@ -42,7 +41,7 @@ class DNSBaseRequestHandler(socketserver.BaseRequestHandler):
         zone.rdclass = dns.rdataclass.IN
 
         nb_records = Record.objects.filter(
-            zone=nb_zone, status=RecordStatusChoices.STATUS_ACTIVE
+            zone=nb_zone, active=True
         )
 
         rdatasets_dict = {}


### PR DESCRIPTION
The original code uses checks against `RecordStatusChoices.STATUS_ACTIVE` and `ZoneStatusChoices.STATUS_ACTIVE` to check whether a record or zone is active in the NetBox DNS data model.

The issue with that is that it is possible to configure custom zone and record statuses in the NetBox DNS configuration, and the two aforementioned statuses are not necessarily the only active statuses. This is govened by the NetBox DNS configuraztion settings "zone_active_status" and "record_active_status".

By using the `active` annotation that `ZoneManager` and `RecordManager` provide, this problem can be avoided (and the code is much simpler, too :-)).