### PR TITLE
Fix/catalog zone get or create

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ multiple views yields unpredicted behavior.
 #### NOTIFY
 Clients may be notified of zone changes using the NOTIFY mechanism defined in RFC 1996.
 When enabled, the zone transfer endpoint keeps track of any client that successfully queried the
-endpoint and when a zone changes. Once a zone has changed, NetBox informs each client of said
-change.
+endpoint. Once a zone has changed, NetBox informs each client about the zone changed so that the
+client can request a new zone transfer.
 
 Note that this feature uses NetBox's background job system to schedule the messages asynchronously.
 In order to work, you need at least one `rq-worker` service running in the background to handle

--- a/netbox_dns_bridge/__init__.py
+++ b/netbox_dns_bridge/__init__.py
@@ -2,7 +2,7 @@ from netbox.plugins import PluginConfig
 from django.conf import settings
 from .logger import get_logger
 
-__version__ = "1.5.5"
+__version__ = "1.5.6"
 
 LOGGER = get_logger(__name__)
 

--- a/netbox_dns_bridge/__init__.py
+++ b/netbox_dns_bridge/__init__.py
@@ -2,7 +2,7 @@ from netbox.plugins import PluginConfig
 from django.conf import settings
 from .logger import get_logger
 
-__version__ = "1.5.4"
+__version__ = "1.5.5"
 
 LOGGER = get_logger(__name__)
 

--- a/netbox_dns_bridge/catalog_zone_manager.py
+++ b/netbox_dns_bridge/catalog_zone_manager.py
@@ -15,7 +15,7 @@ LOGGER = get_logger(__name__)
 def increment_soa_serial() -> int:
     with transaction.atomic():
         try:
-            soa_serial_obj = (
+            soa_serial_obj, _ = (
                 IntegerKeyValueSetting.objects.select_for_update().get_or_create(
                     key="catalog-zone-soa-serial",
                     defaults={"value": 1},
@@ -137,9 +137,10 @@ def update_member_identifier(zone: NBZone) -> None:
 
 def _create_soa_rdataset() -> dns.rdataset:
     try:
-        serial = IntegerKeyValueSetting.objects.get_or_create(
+        serial_obj, _ = IntegerKeyValueSetting.objects.get_or_create(
             key="catalog-zone-soa-serial", defaults={"value": 1}
-        ).value
+        )
+        serial = serial_obj.value
 
         # SOA Record components
         ttl = 0

--- a/netbox_dns_bridge/catalog_zone_manager.py
+++ b/netbox_dns_bridge/catalog_zone_manager.py
@@ -3,16 +3,11 @@ import dns.zone
 import dns.rdatatype
 import dns.rdataclass
 from .logger import get_logger
-from netbox_dns.models import Zone
+from netbox_dns.models import Zone as NBZone
 from netbox_dns_bridge.models import IntegerKeyValueSetting, CatalogZoneMemberIdentifier
 from uuid import uuid4
 from base64 import b32encode
-from django.db import (
-    transaction,
-    close_old_connections,
-    OperationalError,
-    RelatedObjectDoesNotExist
-)
+from django.db import transaction, close_old_connections, OperationalError
 
 LOGGER = get_logger(__name__)
 
@@ -58,7 +53,7 @@ def create_zone(name, view_name) -> dns.zone.Zone:
 
     try:
         # get zones from netbox
-        nb_zones = Zone.objects.filter(
+        nb_zones = NBZone.objects.filter(
             view__name=view_name, active=True
         ).select_related("catz_identifier")
 
@@ -71,9 +66,9 @@ def create_zone(name, view_name) -> dns.zone.Zone:
             # Create PTR record
             try:
                 catz_identifier = nb_zone.catz_identifier
-            except RelatedObjectDoesNotExist:
-                catz_identifier = nb_zone.catz_identifier.create(
-                    name=_generate_member_identifier()
+            except NBZone.catz_identifier.RelatedObjectDoesNotExist:
+                catz_identifier = CatalogZoneMemberIdentifier.objects.create(
+                    zone=nb_zone, name=_generate_member_identifier()
                 )
 
             p_name = catz_identifier.name
@@ -129,7 +124,7 @@ def _generate_member_identifier() -> str:
     return b32encode(uuid4().bytes)[0:26].lower().decode("UTF-8")
 
 
-def update_member_identifier(zone: Zone) -> None:
+def update_member_identifier(zone: NBZone) -> None:
     try:
         CatalogZoneMemberIdentifier.objects.update_or_create(
             zone=zone,


### PR DESCRIPTION
### Title:


Fix 'tuple' object has no attribute 'value' from unpacked get_or_create()
Body:


### Problem
On NetBox 4.6.4 / Django 6.0.5, `netbox_dns_bridge` raises
`AttributeError: 'tuple' object has no attribute 'value'` at runtime.

`QuerySet.get_or_create()` returns a `(obj, created)` tuple, but two call
sites in `catalog_zone_manager.py` (introduced in v1.5.4 and still present
in v1.5.6) use the return value directly:

- `increment_soa_serial()` — raised on **every zone save**
- `_create_soa_rdataset()` — raised on **every catalog-zone (catz) query**

Traceback (catz query):
File ".../catalog_zone_manager.py", line 147, in _create_soa_rdataset
).value
AttributeError: 'tuple' object has no attribute 'value'



### Fix
Unpack the tuple in both places (`obj, _ = ...get_or_create(...)`), then read
`.value` from the object. No behavior change beyond no longer crashing.

### Testing
Deployed on NetBox 4.6.4 / Django 6.0.5: `manage.py check` clean, catz AXFR/SOA
queries and zone saves no longer raise, catalog SOA serial increments correctly.