### PR TITLE
Feature/force notify ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## Unreleased
-- Add `custom_field_force_notify` setting. When set to the name of a boolean custom field on the
-  NetBox DNS Zone object, the plugin sends a NOTIFY directly to a zone's own nameservers whenever
-  the zone has that custom field set to `True` and its SOA serial number changes. Nameserver
-  addresses are resolved from NetBox DNS A/AAAA records within the zone's view and the NOTIFY is
-  signed with the per-view TSIG key. A companion `force_notify_port` setting (default 53) controls
-  the destination port.
+- Add the option to send a NOTIFY directly to a zone's own nameservers when its SOA serial number
+  changes. Enable it per zone via a boolean custom field named by `notify_ns_custom_field_name`,
+  globally for all zones via `notify_ns_all_zones` (default `False`), or both. Nameserver addresses
+  are resolved from NetBox DNS A/AAAA records within the zone's view and the NOTIFY is signed with
+  the per-view TSIG key. A companion `notify_ns_port` setting (default 53) controls the destination
+  port.
 
 ## 1.0.7 - 2026-03-02
 README Change - Moving private keys to global scope since Bind 9.20 view scoped keys have become unreliable and sometimes wouldnt match.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+- Add `custom_field_force_notify` setting. When set to the name of a boolean custom field on the
+  NetBox DNS Zone object, the plugin sends a NOTIFY directly to a zone's own nameservers whenever
+  the zone has that custom field set to `True` and its SOA serial number changes. Nameserver
+  addresses are resolved from NetBox DNS A/AAAA records within the zone's view and the NOTIFY is
+  signed with the per-view TSIG key. A companion `force_notify_port` setting (default 53) controls
+  the destination port.
+
 ## 1.0.7 - 2026-03-02
 README Change - Moving private keys to global scope since Bind 9.20 view scoped keys have become unreliable and sometimes wouldnt match.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,36 @@ list of clients to be notified on zone changes. Default is 24 hours.
 ```
 Switch to using TCP instead of UDP. Defaults to False
 
+#### Forced NOTIFY to a zone's nameservers
+In addition to notifying clients that queried the transfer endpoint, the plugin can send a NOTIFY
+directly to a zone's own nameservers whenever that zone's SOA serial number changes. This is useful
+when you want specific zones to have their nameservers pull updates immediately, independent of the
+`notify_clients` mechanism.
+
+The feature is driven by a boolean custom field on the NetBox DNS Zone object. Create a boolean
+custom field (e.g. `dns_bridge_force_notify_ns`) that applies to `netbox_dns > zone`, then point the
+plugin at it:
+```
+'custom_field_force_notify': 'dns_bridge_force_notify_ns'
+```
+When this setting is present, every time a zone whose custom field is set to `True` changes its SOA
+serial number, the plugin schedules a background NOTIFY to each of the zone's configured nameservers.
+Only a change of the SOA serial triggers this — other zone edits that leave the serial untouched do
+not. The setting is unset by default, which disables the feature entirely.
+
+The nameserver addresses are resolved from NetBox DNS itself by looking up active A/AAAA records
+(within the zone's view) matching each nameserver's hostname. The NOTIFY messages are signed with the
+same per-view TSIG key configured under `tsig_keys`, so the receiving nameservers must accept NOTIFY
+signed with that key (e.g. BIND's `allow-notify { key "..."; };`).
+
+```
+'force_notify_port': 53
+```
+Destination port used for these forced NOTIFY messages. Defaults to 53.
+
+As with the client NOTIFY feature, this uses NetBox's background job system, so at least one
+`rq-worker` service must be running.
+
 ## Plugin compatibility
 This plugin extends the netbox-plugin-dns plugin. As such the versioning was changed to match the
 one of netbox-plugin-dns more closely. To guarantee compatability, ensure that the major and minor

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ multiple views yields unpredicted behavior.
 #### NOTIFY
 Clients may be notified of zone changes using the NOTIFY mechanism defined in RFC 1996.
 When enabled, the zone transfer endpoint keeps track of any client that successfully queried the
-endpoint and when a zone changes. Once a zone has changed, NetBox informs each client of said
-change.
+endpoint. Once a zone has changed, NetBox informs each client about the zone changed so that the
+client can request a new zone transfer.
 
 Note that this feature uses NetBox's background job system to schedule the messages asynchronously.
 In order to work, you need at least one `rq-worker` service running in the background to handle

--- a/README.md
+++ b/README.md
@@ -98,22 +98,31 @@ list of clients to be notified on zone changes. Default is 24 hours.
 ```
 Switch to using TCP instead of UDP. Defaults to False
 
-#### Forced NOTIFY to a zone's nameservers
+#### NOTIFY to a zone's own nameservers
 In addition to notifying clients that queried the transfer endpoint, the plugin can send a NOTIFY
 directly to a zone's own nameservers whenever that zone's SOA serial number changes. This is useful
-when you want specific zones to have their nameservers pull updates immediately, independent of the
-`notify_clients` mechanism.
-
-The feature is driven by a boolean custom field on the NetBox DNS Zone object. Create a boolean
-custom field (e.g. `dns_bridge_force_notify_ns`) that applies to `netbox_dns > zone`, then point the
-plugin at it:
-```
-'custom_field_force_notify': 'dns_bridge_force_notify_ns'
-```
-When this setting is present, every time a zone whose custom field is set to `True` changes its SOA
-serial number, the plugin schedules a background NOTIFY to each of the zone's configured nameservers.
+when you want nameservers to pull updates immediately, independent of the `notify_clients` mechanism.
 Only a change of the SOA serial triggers this — other zone edits that leave the serial untouched do
-not. The setting is unset by default, which disables the feature entirely.
+not.
+
+This can be enabled per zone, globally, or both. If neither of the settings below is configured, the
+feature is disabled entirely.
+
+**Per zone (custom field).** Create a boolean custom field (e.g. `dns_bridge_notify_ns`) that applies
+to `netbox_dns > zone`, then point the plugin at it:
+```
+'notify_ns_custom_field_name': 'dns_bridge_notify_ns'
+```
+A NOTIFY is then sent for any zone whose custom field is set to `True`. This lets you toggle the
+behavior per zone straight from the NetBox UI, without changing the plugin config.
+
+**Globally (all zones).**
+```
+'notify_ns_all_zones': True
+```
+When enabled, a NOTIFY is sent for every zone on serial change, regardless of the custom field.
+Defaults to `False`. The two options coexist: a NOTIFY is sent if the global switch is on **or** the
+zone's custom field is set.
 
 The nameserver addresses are resolved from NetBox DNS itself by looking up active A/AAAA records
 (within the zone's view) matching each nameserver's hostname. The NOTIFY messages are signed with the
@@ -121,9 +130,9 @@ same per-view TSIG key configured under `tsig_keys`, so the receiving nameserver
 signed with that key (e.g. BIND's `allow-notify { key "..."; };`).
 
 ```
-'force_notify_port': 53
+'notify_ns_port': 53
 ```
-Destination port used for these forced NOTIFY messages. Defaults to 53.
+Destination port used for these NOTIFY messages. Defaults to 53.
 
 As with the client NOTIFY feature, this uses NetBox's background job system, so at least one
 `rq-worker` service must be running.

--- a/netbox_dns_bridge/__init__.py
+++ b/netbox_dns_bridge/__init__.py
@@ -2,7 +2,7 @@ from netbox.plugins import PluginConfig
 from django.conf import settings
 from .logger import get_logger
 
-__version__ = "1.5.5"
+__version__ = "1.5.6"
 
 LOGGER = get_logger(__name__)
 

--- a/netbox_dns_bridge/__init__.py
+++ b/netbox_dns_bridge/__init__.py
@@ -2,7 +2,7 @@ from netbox.plugins import PluginConfig
 from django.conf import settings
 from .logger import get_logger
 
-__version__ = "1.5.4"
+__version__ = "1.5.5"
 
 LOGGER = get_logger(__name__)
 

--- a/netbox_dns_bridge/catalog_zone_manager.py
+++ b/netbox_dns_bridge/catalog_zone_manager.py
@@ -3,16 +3,11 @@ import dns.zone
 import dns.rdatatype
 import dns.rdataclass
 from .logger import get_logger
-from netbox_dns.models import Zone
+from netbox_dns.models import Zone as NBZone
 from netbox_dns_bridge.models import IntegerKeyValueSetting, CatalogZoneMemberIdentifier
 from uuid import uuid4
 from base64 import b32encode
-from django.db import (
-    transaction,
-    close_old_connections,
-    OperationalError,
-    RelatedObjectDoesNotExist
-)
+from django.db import transaction, close_old_connections, OperationalError
 
 LOGGER = get_logger(__name__)
 
@@ -58,7 +53,7 @@ def create_zone(name, view_name) -> dns.zone.Zone:
 
     try:
         # get zones from netbox
-        nb_zones = Zone.objects.filter(
+        nb_zones = NBZone.objects.filter(
             view__name=view_name, active=True
         ).select_related("catz_identifier")
 
@@ -71,9 +66,9 @@ def create_zone(name, view_name) -> dns.zone.Zone:
             # Create PTR record
             try:
                 catz_identifier = nb_zone.catz_identifier
-            except RelatedObjectDoesNotExist:
-                catz_identifier = nb_zone.catz_identifier.create(
-                    name=_generate_member_identifier()
+            except NBZone.catz_identifier.RelatedObjectDoesNotExist:
+                catz_identifier = CatalogZoneMemberIdentifier.objects.create(
+                    zone=nb_zone, name=_generate_member_identifier()
                 )
 
             p_name = catz_identifier.name
@@ -129,7 +124,7 @@ def _generate_member_identifier() -> str:
     return b32encode(uuid4().bytes)[0:26].lower().decode("UTF-8")
 
 
-def update_member_identifier(zone: Zone) -> None:
+def update_member_identifier(zone: NBZone) -> None:
     try:
         CatalogZoneMemberIdentifier.objects.update_or_create(
             zone=zone,

--- a/netbox_dns_bridge/notify_handler.py
+++ b/netbox_dns_bridge/notify_handler.py
@@ -18,34 +18,33 @@ LOGGER = get_logger(__name__)
 SETTINGS = settings.PLUGINS_CONFIG["netbox_dns_bridge"]
 
 
+def _load_tsig_key(view_name: str) -> dns.tsig.Key:
+    tsig_keys = SETTINGS.get("tsig_keys", {})
+    if view_name not in tsig_keys:
+        raise RuntimeError(f"No TSIG key configured for view '{view_name}'")
+
+    key_data = tsig_keys[view_name]
+    raw_key_name = key_data.get("keyname")
+    secret = key_data.get("secret")
+    algorithm = key_data.get("algorithm")
+    if not algorithm:
+        raise RuntimeError(
+            f"Missing 'algorithm' in TSIG key configuration for view '{view_name}'"
+        )
+
+    if not raw_key_name or not secret:
+        raise RuntimeError(f"Incomplete TSIG key configuration for view '{view_name}'")
+
+    key_name = dns.name.from_text(raw_key_name, origin=None).canonicalize()
+    if not key_name.is_absolute():
+        key_name = key_name.concatenate(dns.name.root)
+
+    return dns.tsig.Key(name=key_name, secret=secret, algorithm=algorithm)
+
+
 class SendDNSNotify(JobRunner):
     class Meta:
         name = "Send DNS NOTIFY"
-
-    def _load_tsig_key(self, view_name: str) -> dns.tsig.Key:
-        tsig_keys = SETTINGS.get("tsig_keys", {})
-        if view_name not in tsig_keys:
-            raise RuntimeError(f"No TSIG key configured for view '{view_name}'")
-
-        key_data = tsig_keys[view_name]
-        raw_key_name = key_data.get("keyname")
-        secret = key_data.get("secret")
-        algorithm = key_data.get("algorithm")
-        if not algorithm:
-            raise RuntimeError(
-                f"Missing 'algorithm' in TSIG key configuration for view '{view_name}'"
-            )
-
-        if not raw_key_name or not secret:
-            raise RuntimeError(
-                f"Incomplete TSIG key configuration for view '{view_name}'"
-            )
-
-        key_name = dns.name.from_text(raw_key_name, origin=None).canonicalize()
-        if not key_name.is_absolute():
-            key_name = key_name.concatenate(dns.name.root)
-
-        return dns.tsig.Key(name=key_name, secret=secret, algorithm=algorithm)
 
     def run(self, *args, **kwargs):
         notify_over_tcp = SETTINGS.get("notify_over_tcp", False)
@@ -63,7 +62,7 @@ class SendDNSNotify(JobRunner):
             ]
 
             view = View.objects.get(name=view_name)
-            tsig_key = self._load_tsig_key(view_name)
+            tsig_key = _load_tsig_key(view_name)
             cutoff_hours = SETTINGS.get("notify_client_alive_threshold_hours", 24)
             seen_cutoff = timezone.now() - timezone.timedelta(hours=cutoff_hours)
 
@@ -112,24 +111,155 @@ class SendDNSNotify(JobRunner):
             close_old_connections()
 
 
-def schedule(zone: Zone):
+class SendForcedNSNotify(JobRunner):
+    """Send a NOTIFY straight to a zone's own nameservers.
+
+    Unlike ``SendDNSNotify`` (which notifies clients that previously queried the
+    transfer endpoint), this job resolves the addresses of the zone's configured
+    nameservers from NetBox DNS itself and notifies each of them so they pick up
+    the changed zone quickly.
+    """
+
+    class Meta:
+        name = "Send forced DNS NOTIFY to zone nameservers"
+
+    def run(self, *args, **kwargs):
+        notify_over_tcp = SETTINGS.get("notify_over_tcp", False)
+        port = SETTINGS.get("force_notify_port", 53)
+        view_name = kwargs["view_name"]
+        zone_name = kwargs["zone_name"]
+        soa_serial = kwargs["soa_serial"]
+
+        try:
+            zone = Zone.objects.get(pk=kwargs["zone_id"])
+        except Zone.DoesNotExist:
+            LOGGER.error(f"Forced NOTIFY: zone id {kwargs['zone_id']} no longer exists")
+            return
+        except OperationalError as e:
+            LOGGER.error(f"Forced NOTIFY failed due to unexpected error: {e}")
+            close_old_connections()
+            return
+
+        ns_targets = _resolve_zone_nameserver_ips(zone)
+        if not ns_targets:
+            LOGGER.warning(
+                f"Forced NOTIFY: no nameserver addresses found in NetBox DNS for "
+                f"{view_name}/{zone_name} — skipping"
+            )
+            return
+
+        try:
+            tsig_key = _load_tsig_key(view_name)
+        except RuntimeError as e:
+            LOGGER.error(
+                f"Forced NOTIFY aborted for {view_name}/{zone_name}: {e}"
+            )
+            return
+
+        fqdn = dns.name.from_text(zone_name, dns.name.root).to_text()
+        msg = dns.message.make_query(fqdn, dns.rdatatype.SOA)
+        msg.flags |= dns.flags.AA
+        msg.set_opcode(dns.opcode.NOTIFY)
+
+        soa_rdata = dns.rdata.from_text(
+            dns.rdataclass.IN,
+            dns.rdatatype.SOA,
+            f"invalid. invalid. {soa_serial} 60 10 1209600 0",
+        )
+        msg.authority.append(dns.rrset.from_rdata(fqdn, 0, soa_rdata))
+        msg.use_tsig(keyring={tsig_key.name: tsig_key}, keyname=tsig_key.name)
+
+        for ip in ns_targets:
+            try:
+                if notify_over_tcp:
+                    LOGGER.debug("Sending forced NOTIFY over TCP")
+                    dns.query.tcp(msg, ip, port=port, timeout=2)
+                else:
+                    LOGGER.debug("Sending forced NOTIFY over UDP")
+                    dns.query.udp(msg, ip, port=port, timeout=2)
+
+                LOGGER.info(
+                    f"Forced NOTIFY sent: {ip} {view_name}/{fqdn} {soa_serial}"
+                )
+            except Exception as e:
+                LOGGER.error(
+                    f"Forced NOTIFY failed: {ip} {view_name}/{fqdn} {soa_serial}: {e}"
+                )
+
+
+def _get_soa_serial(zone: Zone):
+    """Return the current SOA serial of a zone parsed from its SOA record."""
     try:
         soa_record = Record.objects.filter(zone=zone, type="SOA", active=True).first()
         if soa_record is None:
             LOGGER.error(f"Zone {zone.name} has no active SOA record — skipping NOTIFY")
-            return
+            return None
 
-        soa_serial = int(soa_record.value.split()[2])
+        return int(soa_record.value.split()[2])
 
     except OperationalError as e:
         LOGGER.error(f"DB ERROR while fetching SOA for zone {zone.name}: {e}")
         close_old_connections()
-        return
+        return None
     except (ValueError, IndexError) as e:
         LOGGER.error(f"Failed to parse SOA serial for zone {zone.name}: {e}")
+        return None
+
+
+def _resolve_zone_nameserver_ips(zone: Zone) -> list:
+    """Resolve the zone's nameserver hostnames to IPs using NetBox DNS records.
+
+    For each nameserver assigned to the zone, matching active A/AAAA records
+    within the same view are looked up in NetBox DNS. Returns a de-duplicated,
+    order-preserving list of IP addresses.
+    """
+    ips = []
+    try:
+        nameservers = list(zone.nameservers.all())
+        view = zone.view
+
+        for nameserver in nameservers:
+            fqdn = dns.name.from_text(nameserver.name, dns.name.root).to_text()
+            # Match both with and without a trailing dot to be resilient against
+            # how the fqdn is stored on the Record model.
+            candidates = {fqdn, fqdn.rstrip(".")}
+
+            records = Record.objects.filter(
+                fqdn__in=list(candidates),
+                type__in=["A", "AAAA"],
+                active=True,
+                zone__view=view,
+            )
+            for record in records:
+                if record.value not in ips:
+                    ips.append(record.value)
+
+    except OperationalError as e:
+        LOGGER.error(f"DB ERROR while resolving nameservers for {zone.name}: {e}")
+        close_old_connections()
+
+    return ips
+
+
+def schedule(zone: Zone):
+    soa_serial = _get_soa_serial(zone)
+    if soa_serial is None:
         return
 
     SendDNSNotify.enqueue(
+        zone_name=zone.name,
+        view_name=zone.view.name,
+        soa_serial=soa_serial,
+    )
+
+
+def schedule_force_ns_notify(zone: Zone):
+    soa_serial = _get_soa_serial(zone)
+    if soa_serial is None:
+        return
+
+    SendForcedNSNotify.enqueue(
+        zone_id=zone.pk,
         zone_name=zone.name,
         view_name=zone.view.name,
         soa_serial=soa_serial,

--- a/netbox_dns_bridge/notify_handler.py
+++ b/netbox_dns_bridge/notify_handler.py
@@ -111,7 +111,7 @@ class SendDNSNotify(JobRunner):
             close_old_connections()
 
 
-class SendForcedNSNotify(JobRunner):
+class SendZoneNSNotify(JobRunner):
     """Send a NOTIFY straight to a zone's own nameservers.
 
     Unlike ``SendDNSNotify`` (which notifies clients that previously queried the
@@ -121,11 +121,11 @@ class SendForcedNSNotify(JobRunner):
     """
 
     class Meta:
-        name = "Send forced DNS NOTIFY to zone nameservers"
+        name = "Send DNS NOTIFY to zone nameservers"
 
     def run(self, *args, **kwargs):
         notify_over_tcp = SETTINGS.get("notify_over_tcp", False)
-        port = SETTINGS.get("force_notify_port", 53)
+        port = SETTINGS.get("notify_ns_port", 53)
         view_name = kwargs["view_name"]
         zone_name = kwargs["zone_name"]
         soa_serial = kwargs["soa_serial"]
@@ -133,17 +133,17 @@ class SendForcedNSNotify(JobRunner):
         try:
             zone = Zone.objects.get(pk=kwargs["zone_id"])
         except Zone.DoesNotExist:
-            LOGGER.error(f"Forced NOTIFY: zone id {kwargs['zone_id']} no longer exists")
+            LOGGER.error(f"NS NOTIFY: zone id {kwargs['zone_id']} no longer exists")
             return
         except OperationalError as e:
-            LOGGER.error(f"Forced NOTIFY failed due to unexpected error: {e}")
+            LOGGER.error(f"NS NOTIFY failed due to unexpected error: {e}")
             close_old_connections()
             return
 
         ns_targets = _resolve_zone_nameserver_ips(zone)
         if not ns_targets:
             LOGGER.warning(
-                f"Forced NOTIFY: no nameserver addresses found in NetBox DNS for "
+                f"NS NOTIFY: no nameserver addresses found in NetBox DNS for "
                 f"{view_name}/{zone_name} — skipping"
             )
             return
@@ -152,7 +152,7 @@ class SendForcedNSNotify(JobRunner):
             tsig_key = _load_tsig_key(view_name)
         except RuntimeError as e:
             LOGGER.error(
-                f"Forced NOTIFY aborted for {view_name}/{zone_name}: {e}"
+                f"NS NOTIFY aborted for {view_name}/{zone_name}: {e}"
             )
             return
 
@@ -172,18 +172,18 @@ class SendForcedNSNotify(JobRunner):
         for ip in ns_targets:
             try:
                 if notify_over_tcp:
-                    LOGGER.debug("Sending forced NOTIFY over TCP")
+                    LOGGER.debug("Sending NS NOTIFY over TCP")
                     dns.query.tcp(msg, ip, port=port, timeout=2)
                 else:
-                    LOGGER.debug("Sending forced NOTIFY over UDP")
+                    LOGGER.debug("Sending NS NOTIFY over UDP")
                     dns.query.udp(msg, ip, port=port, timeout=2)
 
                 LOGGER.info(
-                    f"Forced NOTIFY sent: {ip} {view_name}/{fqdn} {soa_serial}"
+                    f"NS NOTIFY sent: {ip} {view_name}/{fqdn} {soa_serial}"
                 )
             except Exception as e:
                 LOGGER.error(
-                    f"Forced NOTIFY failed: {ip} {view_name}/{fqdn} {soa_serial}: {e}"
+                    f"NS NOTIFY failed: {ip} {view_name}/{fqdn} {soa_serial}: {e}"
                 )
 
 
@@ -253,12 +253,12 @@ def schedule(zone: Zone):
     )
 
 
-def schedule_force_ns_notify(zone: Zone):
+def schedule_notify_ns(zone: Zone):
     soa_serial = _get_soa_serial(zone)
     if soa_serial is None:
         return
 
-    SendForcedNSNotify.enqueue(
+    SendZoneNSNotify.enqueue(
         zone_id=zone.pk,
         zone_name=zone.name,
         view_name=zone.view.name,

--- a/netbox_dns_bridge/signals/netbox_dns_zones.py
+++ b/netbox_dns_bridge/signals/netbox_dns_zones.py
@@ -15,11 +15,15 @@ def zone_pre_save(sender, instance, **kwargs):
     zone = instance
     if zone.pk:
         try:
-            zone._old_name = sender.objects.only("name").get(pk=zone.pk).name
+            old = sender.objects.only("name", "soa_serial").get(pk=zone.pk)
+            zone._old_name = old.name
+            zone._old_soa_serial = old.soa_serial
         except sender.DoesNotExist:
             zone._old_name = None
+            zone._old_soa_serial = None
     else:
         zone._old_name = None
+        zone._old_soa_serial = None
 
 
 @receiver(post_save, sender=Zone)
@@ -37,12 +41,24 @@ def zone_post_save(sender, instance, created, **kwargs):
     except LookupError:
         pass
 
+    # Determine whether the zone's SOA serial number changed with this save.
+    # A newly created zone is always considered to have a "changed" serial.
+    old_soa_serial = getattr(zone, "_old_soa_serial", None)
+    new_soa_serial = getattr(zone, "soa_serial", None)
+    soa_serial_changed = created or (old_soa_serial != new_soa_serial)
+
     # On commit, increment soa serial and if notify is enabled, schedule bg job.
     def _on_commit():
         catzm.increment_soa_serial()
 
         if SETTINGS.get("notify_clients", False):
             notify_handler.schedule(zone)
+
+        # Force a NOTIFY to the zone's own nameservers when the zone carries the
+        # configured boolean custom field set to True and its SOA serial changed.
+        cf_name = SETTINGS.get("custom_field_force_notify")
+        if cf_name and soa_serial_changed and _force_notify_enabled(zone, cf_name):
+            notify_handler.schedule_force_ns_notify(zone)
 
     transaction.on_commit(_on_commit)
 
@@ -59,3 +75,9 @@ def zone_post_save(sender, instance, created, **kwargs):
 @receiver(post_delete, sender=Zone)
 def zone_post_delete(sender, instance, **kwargs):
     catzm.increment_soa_serial()
+
+
+def _force_notify_enabled(zone, cf_name: str) -> bool:
+    """Return True only if the zone's boolean custom field ``cf_name`` is True."""
+    custom_fields = getattr(zone, "custom_field_data", None) or {}
+    return custom_fields.get(cf_name) is True

--- a/netbox_dns_bridge/signals/netbox_dns_zones.py
+++ b/netbox_dns_bridge/signals/netbox_dns_zones.py
@@ -54,11 +54,10 @@ def zone_post_save(sender, instance, created, **kwargs):
         if SETTINGS.get("notify_clients", False):
             notify_handler.schedule(zone)
 
-        # Force a NOTIFY to the zone's own nameservers when the zone carries the
-        # configured boolean custom field set to True and its SOA serial changed.
-        cf_name = SETTINGS.get("custom_field_force_notify")
-        if cf_name and soa_serial_changed and _force_notify_enabled(zone, cf_name):
-            notify_handler.schedule_force_ns_notify(zone)
+        # Send a NOTIFY to the zone's own nameservers when its SOA serial changed
+        # and the feature is enabled — globally or per zone via a custom field.
+        if soa_serial_changed and _notify_ns_enabled(zone):
+            notify_handler.schedule_notify_ns(zone)
 
     transaction.on_commit(_on_commit)
 
@@ -77,7 +76,19 @@ def zone_post_delete(sender, instance, **kwargs):
     catzm.increment_soa_serial()
 
 
-def _force_notify_enabled(zone, cf_name: str) -> bool:
-    """Return True only if the zone's boolean custom field ``cf_name`` is True."""
+def _notify_ns_enabled(zone) -> bool:
+    """Return True if a NOTIFY to the zone's nameservers should be sent.
+
+    Enabled either globally for every zone via ``notify_ns_all_zones`` or per
+    zone when the boolean custom field named by ``notify_ns_custom_field_name``
+    is set to True on the zone.
+    """
+    if SETTINGS.get("notify_ns_all_zones", False):
+        return True
+
+    cf_name = SETTINGS.get("notify_ns_custom_field_name")
+    if not cf_name:
+        return False
+
     custom_fields = getattr(zone, "custom_field_data", None) or {}
     return custom_fields.get(cf_name) is True


### PR DESCRIPTION
### Title:

Add forced NOTIFY to a zone's nameservers on SOA serial change
Body:

> Depends on #PR1 (the get_or_create tuple fix). Without it the plugin
> crashes at runtime on Django 6, so please merge that first.

### What
Adds an optional mechanism to send a DNS NOTIFY **directly to a zone's own
nameservers** whenever that zone's SOA serial number changes — independent of
the existing `notify_clients` (SeenTransferClients) mechanism.

Driven by a boolean custom field on the NetBox DNS Zone. New plugin settings:

```python
'custom_field_force_notify': 'dns_bridge_force_notify_ns',  # name of a boolean CF on netbox_dns > zone
'force_notify_port': 53,                                    # optional, default 53
```
When `custom_field_force_notify` is set, then on each zone save where

- the zone's boolean custom field is True, and
- the SOA serial number changed (only that event),

the plugin schedules a background NOTIFY to each of the zone's nameservers.

### Details
- Nameserver addresses are resolved from NetBox DNS itself (active A/AAAA records matching each nameserver hostname within the zone's view), not via external DNS.
- NOTIFY messages are TSIG-signed with the per-view key already configured under `tsig_keys`, so receivers need e.g. `allow-notify { key "..."; };`.
- Serial-change detection: the old SOA serial is captured in the Zone `pre_save` signal and compared in `post_save`.
- The feature is disabled by default (setting unset → no behavior change).
- Runs via NetBox's background jobs (`rq-worker` required), like the existing NOTIFY feature.

### Testing
Verified on NetBox 4.6.4 / Django 6.0.5 against a real zone:

- NS hostnames resolved from NetBox DNS to the expected A records
- gate: CF `True` → NOTIFY scheduled; `False`/unset → nothing
- live send confirmed to both nameservers with the correct serial: `Forced NOTIFY sent: <ip> <view>/<zone>. <serial>`

README and CHANGELOG updated.